### PR TITLE
Format YAML in README to be valid YAML.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ The format of all config files is like so:
 ~~~yaml
 timeout: 120
 hosts:
-	- hostname: [db_host_1]
-		username: [db_username]
-		password: [db_password]
-	- hostname: [db_host_2]
-		username: [db_username]
-		password: [db_password]
+    - hostname:   db_host_1
+      username:   db_username
+      password:   db_password
+    - hostname:   db_host_2
+      username:   db_username
+      password:   db_password
 ~~~
 
 ~~~


### PR DESCRIPTION
The YAML indention in the readme is not valid. I was struggling with it for a few minutes and decided I'd submit a PR to get it fixed in case anyone else is following the directions having the same issue. 
![online_yaml_parser](https://cloud.githubusercontent.com/assets/1200195/11941476/8c0dac30-a7f5-11e5-80dd-61b5f54384c2.png)
